### PR TITLE
Ccb 5053 allow capturing exchange response headers

### DIFF
--- a/ExchangeWebServices.php
+++ b/ExchangeWebServices.php
@@ -1641,7 +1641,7 @@ class ExchangeWebServices
     }
 
     /**
-     * The response headers of the last call, only if setDownloadResponseHeaders(true) called
+     * The response headers of the last call, only if setEnableResponseHeaders(true) called
      *
      * @return string response headers
      */

--- a/ExchangeWebServices.php
+++ b/ExchangeWebServices.php
@@ -155,6 +155,11 @@ class ExchangeWebServices
     protected $file_output;
 
     /**
+     * @var bool Whether or not to get response headers
+     */
+    protected $enable_response_headers = false;
+
+	/**
      * Constructor for the ExchangeWebServices class
      *
      * @param string $server
@@ -1424,6 +1429,7 @@ class ExchangeWebServices
                 break;
         }
 
+        $this->soap->setEnableResponseHeaders($this->enable_response_headers);
         return $this->soap;
     }
 
@@ -1627,7 +1633,7 @@ class ExchangeWebServices
      */
     public function setEnableResponseHeaders($enable_response_headers)
     {
-        return $this->soap->setEnableResponseHeaders($enable_response_headers);
+        $this->enable_response_headers = $enable_response_headers;
     }
 
     /**
@@ -1641,7 +1647,7 @@ class ExchangeWebServices
     }
 
     /**
-     * The response headers of the last call, only if setEnableResponseHeaders(true) called
+     * The response headers of the last call, only if setDownloadResponseHeaders(true) called
      *
      * @return string response headers
      */

--- a/ExchangeWebServices.php
+++ b/ExchangeWebServices.php
@@ -1618,4 +1618,35 @@ class ExchangeWebServices
 
         return $assoc;
     }
+
+    /**
+     * Sets whether to get response headers during a call.
+     * Set this before the call, then after the call, call getResponseHeaders() to get them.
+     *
+     * @param bool $enable_response_headers
+     */
+    public function setEnableResponseHeaders($enable_response_headers)
+    {
+        return $this->soap->setEnableResponseHeaders($enable_response_headers);
+    }
+
+    /**
+     * The request headers of the last call
+     *
+     * @return string Request headers
+     */
+    public function getRequestHeaders()
+    {
+        return $this->soap->__getLastRequestHeaders();
+    }
+
+    /**
+     * The response headers of the last call, only if setDownloadResponseHeaders(true) called
+     *
+     * @return string response headers
+     */
+    public function getResponseHeaders()
+    {
+        return $this->soap->__getLastResponseHeaders();
+    }
 }


### PR DESCRIPTION
This PR is to allow calling apps to collect header data, mostly for responding to Microsoft requests in order to diagnose issues.

It adds the following to ExchangeWebServices:
* If setEnableResponseHeaders(true) is called, the response headers will be available from getResponseHeaders()
* Added getRequestHeaders()

And in OAuthSoapClient, fixed bug in __getLastRequestHeaders() that it was returning headers separated with 'n' characters rather than '\n'.
