### PR TITLE
CCB-5023 Replace default user agent and allow override

### DIFF
--- a/ExchangeWebServices.php
+++ b/ExchangeWebServices.php
@@ -159,6 +159,11 @@ class ExchangeWebServices
      */
     protected $enable_response_headers = false;
 
+    /**
+     * @var string User agent string to attach to the requests
+     */
+    protected $user_agent = 'github-php-ews-generic';
+
 	/**
      * Constructor for the ExchangeWebServices class
      *
@@ -1430,6 +1435,7 @@ class ExchangeWebServices
         }
 
         $this->soap->setEnableResponseHeaders($this->enable_response_headers);
+        $this->soap->setUserAgent($this->user_agent);
         return $this->soap;
     }
 
@@ -1654,5 +1660,15 @@ class ExchangeWebServices
     public function getResponseHeaders()
     {
         return $this->soap->__getLastResponseHeaders();
+    }
+
+    /**
+     * Set the user agent to be used for calls
+     *
+     * @param string $user_agent The user agent to be used for calls
+     */
+    public function setUserAgent($user_agent)
+    {
+        $this->user_agent = $user_agent;
     }
 }

--- a/OAuthSoapClient.php
+++ b/OAuthSoapClient.php
@@ -60,7 +60,7 @@ class OAuthSoapClient extends SoapClient
     /**
      * @var string User agent string to attach to the requests
      */
-    protected $user_agent = 'barracuda-php-ews-LSdbnCFJzf';
+    protected $user_agent = 'github-php-ews-generic';
 
     /**
      * @var bool Whether or not to get response headers
@@ -313,5 +313,15 @@ class OAuthSoapClient extends SoapClient
     public function setEnableResponseHeaders($enable_response_headers)
     {
         $this->enable_response_headers = $enable_response_headers;
+    }
+
+    /**
+     * Set the user agent to be used for calls
+     *
+     * @param string $user_agent The user agent to be used for calls
+     */
+    public function setUserAgent($user_agent)
+    {
+        $this->user_agent = $user_agent;
     }
 }


### PR DESCRIPTION
The github version of the UA will be "github-php-ews-generic", the CCB version will be "barracuda-ews-ccb" (not in this source, in the Exchange365client.php).

MS say it doesn't matter what the UA is as long as it's distinct so that they can use it when diagnosing issues (filter by UA) so the only purpose of this is to avoid http calls from other users of this library being mixed in with ours by MS support.
