### PR TITLE
Detect and throw disk access problems

### DIFF
--- a/EWS_Infrastructure_Exception.php
+++ b/EWS_Infrastructure_Exception.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Contains EWS_Exception.
+ */
+
+/**
+ * Exception class for Exchange Web Services, for infrastructure issues (eg disk space) not connectivity issues
+ *
+ * @package php-ews\Exception
+ */
+class EWS_Infrastructure_Exception extends EWS_Exception
+{
+}

--- a/ExchangeWebServices.php
+++ b/ExchangeWebServices.php
@@ -1634,7 +1634,23 @@ class ExchangeWebServices
         {
             $file_path = $this->cache_name_callback[0](basename(str_replace('/', '', $assoc->ItemId->Id)));
             $cache_handle = fopen($file_path, 'w');
-            fwrite($cache_handle, base64_decode($assoc->MimeContent));
+            if ($cache_handle === false)
+            {
+                throw new EWS_Infrastructure_Exception(
+                    "EWS failed to open file '$file_path'"
+                );
+            }
+
+            $binary = base64_decode($assoc->MimeContent);
+            $written = fwrite($cache_handle, $binary);
+            if (strlen($binary) !== $written)
+            {
+                throw new EWS_Infrastructure_Exception(
+                    "EWS failed to write to '$file_path', expecting to write " .
+                    strlen($binary) . " bytes but only wrote $written bytes"
+                );
+            }
+
             fclose($cache_handle);
             $assoc->MimeContent = $file_path;
         }


### PR DESCRIPTION
Added detection of issues caused by file open or file write. If found, will throw a new exception derived from existing EWS exception so existing code catching generic EWS issues will catch the new detected issues.